### PR TITLE
fix(cosmetics): keep small player arms attached while swinging

### DIFF
--- a/src/main/kotlin/me/owdding/lib/cosmetics/MlibCosmetics.kt
+++ b/src/main/kotlin/me/owdding/lib/cosmetics/MlibCosmetics.kt
@@ -88,7 +88,7 @@ object MlibCosmetics {
         if (!LocationAPI.isOnSkyBlock) return
         state.setData(BABY_MODIFIER_DATA_KEY, cosmetic.small ?: false)
         if (cosmetic.small == true) {
-            state.ageScale = 0.5f
+            state.ageScale = SMALL_PLAYER_AGE_SCALE
             if (state.nameTagAttachment != null) {
                 state.nameTagAttachment = state.nameTagAttachment?.scale(state.ageScale.toDouble())
             }

--- a/src/main/kotlin/me/owdding/lib/cosmetics/ModelConstants.kt
+++ b/src/main/kotlin/me/owdding/lib/cosmetics/ModelConstants.kt
@@ -1,14 +1,30 @@
 package me.owdding.lib.cosmetics
 
 import net.minecraft.client.model.HumanoidModel
+import net.minecraft.client.model.geom.ModelPart
 import net.minecraft.client.model.geom.builders.CubeDeformation
 import net.minecraft.client.model.geom.builders.LayerDefinition
 import net.minecraft.client.model.player.PlayerCapeModel
 import net.minecraft.client.model.player.PlayerModel
 import net.minecraft.client.renderer.entity.ArmorModelSet
+import net.minecraft.client.renderer.entity.state.AvatarRenderState
+
+const val SMALL_PLAYER_AGE_SCALE = 0.5f
+
+private class SmallPlayerModel(root: ModelPart, slim: Boolean) : PlayerModel(root, slim) {
+    override fun setupAnim(state: AvatarRenderState) {
+        val originalAgeScale = state.ageScale
+        state.ageScale = SMALL_PLAYER_AGE_SCALE
+        try {
+            super.setupAnim(state)
+        } finally {
+            state.ageScale = originalAgeScale
+        }
+    }
+}
 
 @JvmField
-val smallPlayerModelWide = PlayerModel(
+val smallPlayerModelWide: PlayerModel = SmallPlayerModel(
     LayerDefinition.create(
         PlayerModel.createMesh(CubeDeformation.NONE, false),
         64,
@@ -18,7 +34,7 @@ val smallPlayerModelWide = PlayerModel(
 )
 
 @JvmField
-val smallPlayerModelSlim = PlayerModel(
+val smallPlayerModelSlim: PlayerModel = SmallPlayerModel(
     LayerDefinition.create(
         PlayerModel.createMesh(CubeDeformation.NONE, true),
         64,
@@ -32,7 +48,7 @@ val babyArmor: ArmorModelSet<PlayerModel> = PlayerModel.createArmorMeshSet(
     CubeDeformation(0.5f),
     CubeDeformation(1f),
 ).map {
-    PlayerModel(
+    SmallPlayerModel(
         LayerDefinition.create(it, 64, 32)
             .apply(HumanoidModel.BABY_TRANSFORMER)
             .bakeRoot(),


### PR DESCRIPTION
Fixes a bug with the small people cosmetic that causes arms to be detached from the player while swinging (noticeable for yourself in third person mode).